### PR TITLE
Copy dataframe when applying intensity match

### DIFF
--- a/massql/msql_engine_filters.py
+++ b/massql/msql_engine_filters.py
@@ -219,7 +219,7 @@ def ms2prod_condition(condition, ms1_df, ms2_df, reference_conditions_register):
         _set_intensity_register(ms2_filtered_df, reference_conditions_register, condition)
 
         # Applying the intensity match
-        ms2_filtered_df = _filter_intensitymatch(ms2_filtered_df, reference_conditions_register, condition)
+        ms2_filtered_df = _filter_intensitymatch(ms2_filtered_df, reference_conditions_register, condition).copy()
         ms2_filtered_df["mzenumeration"] = i
 
         ms2_list.append(ms2_filtered_df)


### PR DESCRIPTION
Encountered warning from line
>ms2_filtered_df = _filter_intensitymatch(ms2_filtered_df, reference_conditions_register, condition)
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy

Using a copy of the dataframe when filtering removes this warning.